### PR TITLE
Add urgency field to ManageIncidentsOptions

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -225,6 +225,7 @@ type ManageIncidentsOptions struct {
 	Status           string            `json:"status,omitempty"`
 	Title            string            `json:"title,omitempty"`
 	Priority         *APIReference     `json:"priority,omitempty"`
+	Urgency          string            `json:"urgency,omitempty"`
 	Assignments      []Assignee        `json:"assignments,omitempty"`
 	EscalationLevel  uint              `json:"escalation_level,omitempty"`
 	EscalationPolicy *APIReference     `json:"escalation_policy,omitempty"`


### PR DESCRIPTION
Forked a whole repo just to add this: https://github.com/PagerDuty/go-pagerduty/pull/540

Required for https://github.com/ClickHouse/sre/issues/61